### PR TITLE
Hide the cite button

### DIFF
--- a/_includes/headers/subhead.html
+++ b/_includes/headers/subhead.html
@@ -63,13 +63,15 @@
   </ul>
 
   <ul id="page-actions">
-    {% if page.layout == 'essay' %}
-      <li>
-        <a aria-label="Cite this essay" class="action-cite" href="#">
-          <i class="fa fa-file-text-o"></i>
-        </a>
-      </li>
-    {% endif %}
+    {% comment %}
+      {% if page.layout == 'essay' %}
+        <li>
+          <a aria-label="Cite this essay" class="action-cite" href="#">
+            <i class="fa fa-file-text-o"></i>
+          </a>
+        </li>
+      {% endif %}
+    {% endcomment %}
 
     <li>
       <a class="action-print" href="javascript:print()" aria-label="Print" >

--- a/_layouts/essay.html
+++ b/_layouts/essay.html
@@ -59,7 +59,12 @@ layout: default
     {%- for author in page.authors -%}
       {{ author.last_name }}, {{ author.first_name }}
     {%- endfor -%}. "{{ page.title }}." <em>Keywords {% if book.layout == 'book' %}for{% else %}Now:{% endif %} {{ book.title }}</em>.
-    Eds. {% include people.html people=book.editors plain=true %}. New York: New York University Press, {{ book.date | date: "%Y"}}. {{ page.page }}. Print.</div>
+      Eds. {% include people.html people=book.editors plain=true %}. New York: New York University Press, {{ book.date | date: "%Y" }}. {{ page.page }}.
+      {% if page.availability contains 'Print' %}
+        Print.
+      {% else %}
+        Online at {{ page.url | absolute_url }} (accessed {{ site.time | date: '%B %e, %Y' }}).
+      {% endif %}</div>
   </div>
 </div>
 

--- a/_layouts/essay.html
+++ b/_layouts/essay.html
@@ -52,6 +52,7 @@ layout: default
 
 {% include_cached footer.html book=book %}
 
+{% comment %}
 <div id="cite-box-overlay" style="display: none;"></div>
 <div id="cite-box" style="display: none;">
   <button><span>close</span></button>
@@ -67,6 +68,7 @@ layout: default
       {% endif %}</div>
   </div>
 </div>
+{% endcomment %}
 
 <div id="scroll-help">
   <a id="up" role="presentation"><i class="fa fa-angle-up"></i></a>

--- a/wp-content/themes/nyukeywords/styleac01.css
+++ b/wp-content/themes/nyukeywords/styleac01.css
@@ -1659,7 +1659,7 @@ footer ul.menu a:hover {
 	top: 50%;
 	left: 50%;
 	width: 300px;
-	height: 240px;
+	min-height: 240px;
 	margin: -120px 0 0 -150px;
 	background: #D93735;
 	z-index:101;
@@ -1697,7 +1697,7 @@ footer ul.menu a:hover {
 #cite-box div {
 	line-height: 1.2em;
 	padding: 0.5em;
-	height: 200px;
+	min-height: 200px;
 	font-family: Georgia, Times New Roman, Times, serif;
 	background: #FFF !important;
 	border: none;


### PR DESCRIPTION
This change hides the cite button and doesn't produce the cite box.  Preview is at keywords.sutty.nl

https://jira.nyu.edu/browse/KEYWORDS-76